### PR TITLE
Rename from aries-bbs-rs to aries-bbssignatures-rs

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -3,6 +3,6 @@
 #
 
 repository:
-  name: aries-bbs-rs
+  name: aries-bbssignatures-rs
   default_branch: main
   archived: false


### PR DESCRIPTION
Rename from `aries-bbs-rs` to `aries-bbssignatures-rs`. The goal is to match the naming convention of the other 2 repos created for `indy-blssignatures-rs` and `anoncreds-clsignatures-rs`.